### PR TITLE
Fix Twitter link on pkgdown site

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -9,7 +9,7 @@ navbar:
   components:
     twitter:
       icon: fa-twitter
-      href: https://twitter.com/paulj1989
+      href: https://twitter.com/paul_johnson89
       aria-label: Twitter
     github:
       icon: fa-github


### PR DESCRIPTION
Because apparently I'm such an idiot I linked to some other person's Twitter. They don't deserve this. They didn't make this monstrosity.